### PR TITLE
Fix build script for cross-compiling

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,14 @@
 extern crate gcc;
 
+use std::env;
+
 fn main() {
-    if cfg!(windows) {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    if target_os == "windows" {
         gcc::compile_library("librunas.a", &["runas-windows.c"]);
         println!("cargo:rustc-link-lib=runas");
         println!("cargo:rustc-link-lib=ole32");
-    } else if cfg!(target_os = "macos") {
+    } else if target_os == "macos" {
         gcc::compile_library("librunas.a", &["runas-darwin.c"]);
         println!("cargo:rustc-link-lib=framework=Security");
         println!("cargo:rustc-link-lib=runas");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,10 @@
 //! ```rust,no_run
 //! use runas::Command;
 //!
-//! let status = try!(Command::new("rm")
+//! let status = Command::new("rm")
 //!     .arg("/usr/local/my-app")
-//!     .status());
+//!     .status()
+//!     .unwrap();
 //! ```
 //!
 //! ## Platform Support


### PR DESCRIPTION
The current build script uses the `cfg!` macro to infer the target OS. However, in the build context, this will always be the host machine and never the actual target. This PR uses [`CARGO_CFG_*` environment variables](https://github.com/rust-lang/cargo/blob/master/src/doc/environment-variables.md#environment-variables-cargo-sets-for-build-scripts) instead.