### PR TITLE
chore(deps) update `which` to 4.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ build = "build.rs"
 edition = "2018"
 
 [dependencies]
-which = "3.1.0"
+which = "4.0.2"
 
 [build-dependencies]
 cc = "1.0.50"


### PR DESCRIPTION
This resolves an audit warning because `which` v3.x depended on `failure`, which if officially deprecated/unmaintained. 