### PR TITLE
bump which to 4.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ build = "build.rs"
 edition = "2018"
 
 [dependencies]
-which = "3.1.0"
+which = "4.3.0"
 
 [build-dependencies]
 cc = "1.0.50"


### PR DESCRIPTION
Bumps `which` to 4.3.0, removing the transitive dependency on the unmaintained `failure` crate.

Was successfully able to build and run the `demo.rs` example.